### PR TITLE
fix: Handle sites with missing `ogUrl` and `ogImage` arrays

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -57243,15 +57243,18 @@ function handleMimeType(type) {
     return matches ? matches[0].replace("jpeg", "jpg") : "jpg";
 }
 function setImage(result) {
-    if (!result.ogImage || !result.ogImage.url || !result.ogTitle)
+    if (!result.ogImage || !result.ogTitle)
         return;
-    const imageType = result.ogImage.type
-        ? `.${handleMimeType(result.ogImage.type)}`
+    const image = Array.isArray(result.ogImage) ? result.ogImage[0] : result.ogImage;
+    if (!image.url)
+        return;
+    const imageType = image.type
+        ? `.${handleMimeType(image.type)}`
         : ".jpg";
-    const image = `bookmark-${slugify(result.ogTitle)}${imageType}`;
-    (0,core.exportVariable)("BookmarkImageOutput", image);
-    (0,core.exportVariable)("BookmarkImage", result.ogImage.url);
-    return image;
+    const imageName = `bookmark-${slugify(result.ogTitle)}${imageType}`;
+    (0,core.exportVariable)("BookmarkImageOutput", imageName);
+    (0,core.exportVariable)("BookmarkImage", image.url);
+    return imageName;
 }
 
 ;// CONCATENATED MODULE: ./src/get-metadata.ts
@@ -57269,11 +57272,15 @@ var get_metadata_awaiter = (undefined && undefined.__awaiter) || function (thisA
 
 function getMetadata({ url, body, date, }) {
     return get_metadata_awaiter(this, void 0, void 0, function* () {
-        const { result } = (yield open_graph_scraper_default()({ url }));
+        const { result, error } = (yield open_graph_scraper_default()({ url }));
+        if (error) {
+            (0,core.setFailed)(`${result}`);
+            return;
+        }
         (0,core.exportVariable)("BookmarkTitle", result.ogTitle);
         (0,core.exportVariable)("DateBookmarked", date);
         const image = setImage(result);
-        return Object.assign({ title: result.ogTitle || "", site: result.ogSiteName || "", date, description: result.ogDescription || "", url: result.ogUrl, image: image || "", type: result.ogType || "" }, (body && { notes: body }));
+        return Object.assign({ title: result.ogTitle || "", site: result.ogSiteName || "", date, description: result.ogDescription || "", url: result.ogUrl || result.requestUrl, image: image || "", type: result.ogType || "" }, (body && { notes: body }));
     });
 }
 

--- a/src/__tests__/fixtures/fullstackdev.json
+++ b/src/__tests__/fixtures/fullstackdev.json
@@ -1,0 +1,131 @@
+{
+  "ogTitle": "You can create a great looking website while sucking at design",
+  "ogDescription": "How to create great looking websites while having little design skill.",
+  "ogImage": [
+    {
+      "url": "https://i.imgur.com/IXSe6YZ.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/8oQmz1o.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/UPuQyTe.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/0abgCJB.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/boApV02.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/qoTi6SV.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/8VplzJE.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/cEWeLxb.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/1wv99Gl.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/QrXEV0k.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/mAUjEjR.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/JKiWbka.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/fhYtCVr.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/ItEdGvZ.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/nlTSCt3.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/vuAX5Rw.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/VOFSxOM.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/ChG9lwV.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/XpHTFkD.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    },
+    {
+      "url": "https://i.imgur.com/G7PheNV.png",
+      "width": null,
+      "height": null,
+      "type": "png"
+    }
+  ],
+  "ogLocale": "en",
+  "favicon": "/favicon.png",
+  "charset": "utf8",
+  "requestUrl": "https://thefullstackdev.net/article/create-beautiful-website-while-sucking-at-design/",
+  "success": true
+}

--- a/src/__tests__/get-metadata.test.ts
+++ b/src/__tests__/get-metadata.test.ts
@@ -1,7 +1,9 @@
 import pen15 from "./fixtures/pen15.json";
 import soup from "./fixtures/slow-cooker-soup.json";
+import fullstack from "./fixtures/fullstackdev.json";
 import ogs from "open-graph-scraper";
 import { getMetadata } from "../get-metadata";
+import { setFailed } from "@actions/core";
 
 jest.mock("open-graph-scraper");
 jest.mock("@actions/core");
@@ -26,6 +28,19 @@ describe("getMetadata", () => {
         "url": "https://www.hulu.com/series/pen15-8c87035d-2b10-4b10-a233-ca5b3597145d",
       }
     `);
+  });
+  test("fails", async () => {
+    ogs.mockResolvedValueOnce({
+      error: true,
+      result: new Error("Page not found"),
+    });
+    expect(
+      await getMetadata({
+        url: "https://www.hulu.com/series/pen15-8c87035d-2b10-4b10-a233-ca5b3597145d",
+        date: "2022-01-01",
+      })
+    ).toMatchInlineSnapshot(`undefined`);
+    expect(setFailed).toHaveBeenCalledWith("Error: Page not found");
   });
   test("recipe, with note", async () => {
     ogs.mockResolvedValueOnce({ result: soup });
@@ -119,6 +134,27 @@ describe("getMetadata", () => {
         "title": "",
         "type": "tv_show",
         "url": "https://www.hulu.com/series/pen15-8c87035d-2b10-4b10-a233-ca5b3597145d",
+      }
+    `);
+  });
+  test("bug fix, full stack dev", async () => {
+    ogs.mockResolvedValueOnce({
+      result: fullstack,
+    });
+    expect(
+      await getMetadata({
+        url: "https://thefullstackdev.net/article/create-beautiful-website-while-sucking-at-design/",
+        date: "2022-08-03",
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "date": "2022-08-03",
+        "description": "How to create great looking websites while having little design skill.",
+        "image": "bookmark-you-can-create-a-great-looking-website-while-sucking-at-design.png",
+        "site": "",
+        "title": "You can create a great looking website while sucking at design",
+        "type": "",
+        "url": "https://thefullstackdev.net/article/create-beautiful-website-while-sucking-at-design/",
       }
     `);
   });

--- a/src/get-metadata.ts
+++ b/src/get-metadata.ts
@@ -1,4 +1,4 @@
-import { exportVariable } from "@actions/core";
+import { exportVariable, setFailed } from "@actions/core";
 import ogs from "open-graph-scraper";
 import { setImage } from "./set-image";
 
@@ -11,7 +11,11 @@ export async function getMetadata({
   body?: string;
   date: string;
 }) {
-  const { result } = (await ogs({ url })) as { result: OpenGraphObject };
+  const { result, error } = await ogs({ url });
+  if (error) {
+    setFailed(`${result}`);
+    return;
+  }
   exportVariable("BookmarkTitle", result.ogTitle);
   exportVariable("DateBookmarked", date);
   const image = setImage(result);
@@ -20,18 +24,9 @@ export async function getMetadata({
     site: result.ogSiteName || "",
     date,
     description: result.ogDescription || "",
-    url: result.ogUrl,
+    url: result.ogUrl || result.requestUrl,
     image: image || "",
     type: result.ogType || "",
     ...(body && { notes: body }),
   };
 }
-
-export type OpenGraphObject = {
-  ogTitle: string;
-  ogSiteName: string;
-  ogDescription: string;
-  ogUrl: string;
-  ogType: string;
-  success: boolean;
-};

--- a/src/set-image.ts
+++ b/src/set-image.ts
@@ -8,12 +8,14 @@ function handleMimeType(type: string) {
 }
 
 export function setImage(result) {
-  if (!result.ogImage || !result.ogImage.url || !result.ogTitle) return;
-  const imageType = result.ogImage.type
-    ? `.${handleMimeType(result.ogImage.type)}`
-    : ".jpg";
-  const image = `bookmark-${slugify(result.ogTitle)}${imageType}`;
-  exportVariable("BookmarkImageOutput", image);
-  exportVariable("BookmarkImage", result.ogImage.url);
-  return image;
+  if (!result.ogImage || !result.ogTitle) return;
+  const image = Array.isArray(result.ogImage)
+    ? result.ogImage[0]
+    : result.ogImage;
+  if (!image.url) return;
+  const imageType = image.type ? `.${handleMimeType(image.type)}` : ".jpg";
+  const imageName = `bookmark-${slugify(result.ogTitle)}${imageType}`;
+  exportVariable("BookmarkImageOutput", imageName);
+  exportVariable("BookmarkImage", image.url);
+  return imageName;
 }


### PR DESCRIPTION
This pull request will handle metadata that's missing `ogUrl` and when the `ogImage` is formatted as an array.

Fix #62 