### PR TITLE
Enable dev-defined additional properties

### DIFF
--- a/.github/workflows/bookmarks-advanced.yml
+++ b/.github/workflows/bookmarks-advanced.yml
@@ -1,0 +1,48 @@
+name: Add bookmark with additional properties
+run-name: Add bookmark (${{ inputs.url }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: The URL to bookmark.
+        required: true
+        type: string
+      notes:
+        description: Notes about the bookmark.
+        type: string
+      date:
+        description: Date (YYYY-MM-DD). The default date is today.
+        type: string
+      tags:
+        description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
+        type: string
+      rating:
+        description: Rate the bookmark from 1 to 5. Optional.
+        type: string
+      quote:
+        description: Add a quote from the bookmark. Optional.
+        type: string
+
+jobs:
+  add-bookmark:
+    runs-on: macOS-latest
+    name: Add bookmark
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Bookmark action
+        uses: ./
+        with:
+          filename: _data/recipes.json
+          additional-properties: rating,quote
+      - name: Download the thumbnail image
+        run: curl "${{ env.BookmarkImage }}" -o "img/${{ env.BookmarkImageOutput }}"
+        if: env.BookmarkImage != ''
+      - name: Commit files
+        run: |
+          git pull
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A && git commit -m  "Bookmark ${{ env.BookmarkTitle }}"
+          git push

--- a/.github/workflows/bookmarks-advanced.yml
+++ b/.github/workflows/bookmarks-advanced.yml
@@ -17,7 +17,7 @@ on:
       tags:
         description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
         type: string
-      # The following property names are defined by "additional-properties"
+      # The following property names are defined by the task input "additional-properties"
       rating:
         description: Rate the bookmark from 1 to 5. Optional.
         type: string

--- a/.github/workflows/bookmarks-advanced.yml
+++ b/.github/workflows/bookmarks-advanced.yml
@@ -17,6 +17,7 @@ on:
       tags:
         description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
         type: string
+      # The following property names are defined by "additional-properties"
       rating:
         description: Rate the bookmark from 1 to 5. Optional.
         type: string
@@ -35,6 +36,7 @@ jobs:
         uses: ./
         with:
           filename: _data/recipes.json
+          # You can define additional properties you want to pass through
           additional-properties: rating,quote
       - name: Download the thumbnail image
         run: curl "${{ env.BookmarkImage }}" -o "img/${{ env.BookmarkImageOutput }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - ".github/workflows/bookmarks.yml"
+      - ".github/workflows/bookmarks-advanced.yml"
       - ".github/workflows/documentation.yml"
       - "action.yml"
       - "package.json"
@@ -24,6 +25,7 @@ jobs:
         uses: katydecorah/documentation-action@v1.3.0
         with:
           example-workflow-file: "bookmarks.yml"
+          additional-workflow-file-prefix: "bookmarks"
       - name: Commit files
         if: steps.documentation.outputs.update == 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ on:
       tags:
         description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
         type: string
+      # The following property names are defined by "additional-properties"
       rating:
         description: Rate the bookmark from 1 to 5. Optional.
         type: string
@@ -97,6 +98,7 @@ jobs:
         uses: katydecorah/bookmark-action@v6.3.0
         with:
           filename: _data/recipes.json
+          # You can define additional properties you want to pass through
           additional-properties: rating,quote
       - name: Download the thumbnail image
         run: curl "${{ env.BookmarkImage }}" -o "img/${{ env.BookmarkImageOutput }}"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ on:
       tags:
         description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
         type: string
-      # The following property names are defined by "additional-properties"
+      # The following property names are defined by the task input "additional-properties"
       rating:
         description: Rate the bookmark from 1 to 5. Optional.
         type: string

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ jobs:
 
 - `export-image`: Export the URL's `image` to download later and set `image` property. Default: `true`.
 
+- `additional-properties`: Additional properties to add to the bookmark from the workflow payload formatted as a comma delimited string.
+
 ## Trigger the action
 
 To trigger the action, [create a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) with the following body parameters:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,64 @@ jobs:
           git push
 ```
 
+### Additional example workflows
+
+<details>
+<summary>Add bookmark with additional properties</summary>
+
+```yml
+name: Add bookmark with additional properties
+run-name: Add bookmark (${{ inputs.url }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: The URL to bookmark.
+        required: true
+        type: string
+      notes:
+        description: Notes about the bookmark.
+        type: string
+      date:
+        description: Date (YYYY-MM-DD). The default date is today.
+        type: string
+      tags:
+        description: Add tags to categorize the bookmark. Separate each tag with a comma. Optional.
+        type: string
+      rating:
+        description: Rate the bookmark from 1 to 5. Optional.
+        type: string
+      quote:
+        description: Add a quote from the bookmark. Optional.
+        type: string
+
+jobs:
+  add-bookmark:
+    runs-on: macOS-latest
+    name: Add bookmark
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Bookmark action
+        uses: katydecorah/bookmark-action@v6.3.0
+        with:
+          filename: _data/recipes.json
+          additional-properties: rating,quote
+      - name: Download the thumbnail image
+        run: curl "${{ env.BookmarkImage }}" -o "img/${{ env.BookmarkImageOutput }}"
+        if: env.BookmarkImage != ''
+      - name: Commit files
+        run: |
+          git pull
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A && git commit -m  "Bookmark ${{ env.BookmarkTitle }}"
+          git push
+```
+
+</details>
+
 ## Action options
 
 - `filename`: The filename to save your bookmarks. Default: `_data/bookmarks.json`.

--- a/action.yml
+++ b/action.yml
@@ -12,3 +12,6 @@ inputs:
   export-image:
     description: "Export the URL's `image` to download later and set `image` property."
     default: "true"
+  additional-properties:
+    description: "Additional properties to add to the bookmark from the workflow payload formatted as a comma delimited string."
+    default: ""

--- a/dist/index.js
+++ b/dist/index.js
@@ -68210,8 +68210,23 @@ function getMetadata({ url, notes, date, tags, additionalProperties, }) {
         }
     });
 }
-function toArray(tags) {
-    return tags.split(",").map((f) => f.trim());
+function toArray(string) {
+    if (!string || string == "")
+        return [];
+    return string.split(",").map((f) => f.trim());
+}
+
+;// CONCATENATED MODULE: ./src/set-additional-properties.ts
+
+
+function setAdditionalProperties(payload) {
+    const additionalPropertiesList = toArray((0,core.getInput)("additional-properties"));
+    if (!additionalPropertiesList.length)
+        return undefined;
+    return additionalPropertiesList.reduce((acc, property) => {
+        acc[property] = payload[property];
+        return acc;
+    }, {});
 }
 
 ;// CONCATENATED MODULE: ./src/index.ts
@@ -68224,6 +68239,7 @@ var src_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argu
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+
 
 
 
@@ -68250,13 +68266,7 @@ function action() {
             const date = payload.date || new Date().toISOString().slice(0, 10);
             (0,core.exportVariable)("DateBookmarked", date);
             const filename = (0,core.getInput)("filename");
-            const additionalPropertiesList = (0,core.getInput)("additional-properties")
-                ? toArray((0,core.getInput)("additional-properties"))
-                : undefined;
-            const additionalProperties = additionalPropertiesList === null || additionalPropertiesList === void 0 ? void 0 : additionalPropertiesList.reduce((acc, property) => {
-                acc[property] = payload[property];
-                return acc;
-            }, {});
+            const additionalProperties = setAdditionalProperties(payload);
             const page = (yield getMetadata({
                 url,
                 notes,

--- a/dist/index.js
+++ b/dist/index.js
@@ -68219,6 +68219,7 @@ function toArray(input) {
 ;// CONCATENATED MODULE: ./src/set-additional-properties.ts
 
 
+const MAX_ADDITIONAL_PROPERTIES = 5;
 const reservedKeys = [
     "title",
     "site",
@@ -68244,6 +68245,9 @@ function setAdditionalProperties(payload) {
     });
     if (!additionalPropertiesList.length)
         return undefined;
+    if (additionalPropertiesList.length > MAX_ADDITIONAL_PROPERTIES) {
+        throw new Error(`You can only set ${MAX_ADDITIONAL_PROPERTIES} additional properties. You tried to set ${additionalPropertiesList.length}: ${additionalPropertiesList.join(", ")}`);
+    }
     return additionalPropertiesList.reduce((acc, property) => {
         acc[property] = payload[property];
         return acc;

--- a/dist/index.js
+++ b/dist/index.js
@@ -68219,8 +68219,29 @@ function toArray(string) {
 ;// CONCATENATED MODULE: ./src/set-additional-properties.ts
 
 
+const reservedKeys = [
+    "title",
+    "site",
+    "date",
+    "description",
+    "url",
+    "author",
+    "type",
+    "image",
+    "notes",
+    "tags",
+];
 function setAdditionalProperties(payload) {
-    const additionalPropertiesList = toArray((0,core.getInput)("additional-properties"));
+    let additionalPropertiesList = toArray((0,core.getInput)("additional-properties"));
+    if (!additionalPropertiesList.length)
+        return undefined;
+    additionalPropertiesList = additionalPropertiesList.filter((property) => {
+        if (reservedKeys.includes(property)) {
+            (0,core.warning)(`The additional property "${property}" is reserved and cannot be used`);
+            return false;
+        }
+        return true;
+    });
     if (!additionalPropertiesList.length)
         return undefined;
     return additionalPropertiesList.reduce((acc, property) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -68210,10 +68210,10 @@ function getMetadata({ url, notes, date, tags, additionalProperties, }) {
         }
     });
 }
-function toArray(string) {
-    if (!string || string == "")
+function toArray(input) {
+    if (!(input === null || input === void 0 ? void 0 : input.trim()))
         return [];
-    return string.split(",").map((f) => f.trim());
+    return input.split(",").map((item) => item.trim());
 }
 
 ;// CONCATENATED MODULE: ./src/set-additional-properties.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -68188,7 +68188,7 @@ var get_metadata_awaiter = (undefined && undefined.__awaiter) || function (thisA
 
 
 
-function getMetadata({ url, notes, date, tags, }) {
+function getMetadata({ url, notes, date, tags, additionalProperties, }) {
     var _a, _b;
     return get_metadata_awaiter(this, void 0, void 0, function* () {
         try {
@@ -68201,9 +68201,9 @@ function getMetadata({ url, notes, date, tags, }) {
             if (!waybackUrl) {
                 (0,core.warning)(`No wayback url found for ${url}`);
             }
-            return Object.assign(Object.assign(Object.assign({ title: result.ogTitle || "", site: result.ogSiteName || "", author: result.author || "", date, description: result.ogDescription || "", url: result.ogUrl || result.requestUrl || url, image, type: result.ogType || "" }, (notes && { notes })), (tags && { tags: toArray(tags) })), (waybackUrl && {
+            return Object.assign(Object.assign(Object.assign(Object.assign({ title: result.ogTitle || "", site: result.ogSiteName || "", author: result.author || "", date, description: result.ogDescription || "", url: result.ogUrl || result.requestUrl || url, image, type: result.ogType || "" }, (notes && { notes })), (tags && { tags: toArray(tags) })), (waybackUrl && {
                 waybackUrl,
-            }));
+            })), additionalProperties);
         }
         catch (error) {
             throw new Error(`Error getting metadata for ${url}: ${error.result.error}`);
@@ -68250,7 +68250,20 @@ function action() {
             const date = payload.date || new Date().toISOString().slice(0, 10);
             (0,core.exportVariable)("DateBookmarked", date);
             const filename = (0,core.getInput)("filename");
-            const page = (yield getMetadata({ url, notes, date, tags }));
+            const additionalPropertiesList = (0,core.getInput)("additional-properties")
+                ? toArray((0,core.getInput)("additional-properties"))
+                : undefined;
+            const additionalProperties = additionalPropertiesList === null || additionalPropertiesList === void 0 ? void 0 : additionalPropertiesList.reduce((acc, property) => {
+                acc[property] = payload[property];
+                return acc;
+            }, {});
+            const page = (yield getMetadata({
+                url,
+                notes,
+                date,
+                tags,
+                additionalProperties,
+            }));
             const bookmarks = yield addBookmark(filename, page);
             if (!bookmarks) {
                 (0,core.setFailed)(`Unable to add bookmark`);

--- a/src/__tests__/set-additional-properties.test.ts
+++ b/src/__tests__/set-additional-properties.test.ts
@@ -56,4 +56,23 @@ describe("setAdditionalProperties", () => {
 
     expect(result).toBeUndefined();
   });
+
+  it("throws an error when trying to set more than 5 additional properties", () => {
+    (getInput as jest.MockedFunction<typeof getInput>).mockReturnValueOnce(
+      "prop1,prop2,prop3,prop4,prop5,prop6"
+    );
+
+    const payload = {
+      prop1: "value1",
+      prop2: "value2",
+      prop3: "value3",
+      prop4: "value4",
+      prop5: "value5",
+      prop6: "value6",
+    };
+
+    expect(() => setAdditionalProperties(payload)).toThrow(
+      "You can only set 5 additional properties. You tried to set 6: prop1, prop2, prop3, prop4, prop5, prop6"
+    );
+  });
 });

--- a/src/__tests__/set-additional-properties.test.ts
+++ b/src/__tests__/set-additional-properties.test.ts
@@ -1,0 +1,44 @@
+import { getInput } from "@actions/core";
+import { setAdditionalProperties } from "../set-additional-properties";
+
+jest.mock("@actions/core");
+
+describe("setAdditionalProperties", () => {
+  it("returns undefined when additionalPropertiesList is undefined", () => {
+    const result = setAdditionalProperties({
+      prop1: "value1",
+      prop2: "value2",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when additionalPropertiesList is empty", () => {
+    (getInput as jest.MockedFunction<typeof getInput>).mockReturnValueOnce("");
+
+    const result = setAdditionalProperties({
+      prop1: "value1",
+      prop2: "value2",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns additionalPropertiesList", () => {
+    (getInput as jest.MockedFunction<typeof getInput>).mockReturnValueOnce(
+      "prop1,prop2"
+    );
+
+    const result = setAdditionalProperties({
+      prop1: "value1",
+      prop2: "value2",
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+{
+  "prop1": "value1",
+  "prop2": "value2",
+}
+`);
+  });
+});

--- a/src/__tests__/set-additional-properties.test.ts
+++ b/src/__tests__/set-additional-properties.test.ts
@@ -1,4 +1,4 @@
-import { getInput } from "@actions/core";
+import { getInput, warning } from "@actions/core";
 import { setAdditionalProperties } from "../set-additional-properties";
 
 jest.mock("@actions/core");
@@ -40,5 +40,20 @@ describe("setAdditionalProperties", () => {
   "prop2": "value2",
 }
 `);
+  });
+
+  it("warns and removes reserved properties from the additional properties list", () => {
+    (getInput as jest.MockedFunction<typeof getInput>).mockReturnValueOnce(
+      "url"
+    );
+
+    const payload = { url: "value1", prop2: "value2", title: "value3" };
+    const result = setAdditionalProperties(payload);
+
+    expect(warning).toHaveBeenCalledWith(
+      'The additional property "url" is reserved and cannot be used'
+    );
+
+    expect(result).toBeUndefined();
   });
 });

--- a/src/get-metadata.ts
+++ b/src/get-metadata.ts
@@ -49,6 +49,7 @@ export async function getMetadata({
   }
 }
 
-export function toArray(tags: string): string[] {
-  return tags.split(",").map((f) => f.trim());
+export function toArray(string: string): string[] {
+  if (!string || string == "") return [];
+  return string.split(",").map((f) => f.trim());
 }

--- a/src/get-metadata.ts
+++ b/src/get-metadata.ts
@@ -49,7 +49,7 @@ export async function getMetadata({
   }
 }
 
-export function toArray(string: string): string[] {
-  if (!string || string == "") return [];
-  return string.split(",").map((f) => f.trim());
+export function toArray(input: string): string[] {
+  if (!input?.trim()) return [];
+  return input.split(",").map((item) => item.trim());
 }

--- a/src/get-metadata.ts
+++ b/src/get-metadata.ts
@@ -9,11 +9,13 @@ export async function getMetadata({
   notes,
   date,
   tags,
+  additionalProperties,
 }: {
   url: string;
   notes?: string;
   date: string;
   tags?: string;
+  additionalProperties?: Record<string, string>;
 }): Promise<Bookmark | undefined> {
   try {
     const { result } = await ogs({ url });
@@ -40,12 +42,13 @@ export async function getMetadata({
       ...(waybackUrl && {
         waybackUrl,
       }),
+      ...additionalProperties,
     };
   } catch (error) {
     throw new Error(`Error getting metadata for ${url}: ${error.result.error}`);
   }
 }
 
-function toArray(tags: string): string[] {
+export function toArray(tags: string): string[] {
   return tags.split(",").map((f) => f.trim());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as github from "@actions/github";
 import { isUrl, isDate } from "./utils.js";
 import { saveBookmarks } from "./save-bookmarks";
 import { addBookmark, Bookmark } from "./add-bookmark";
-import { getMetadata } from "./get-metadata";
+import { getMetadata, toArray } from "./get-metadata";
 
 type Payload = {
   url: string;
@@ -37,7 +37,25 @@ export async function action() {
 
     const filename = getInput("filename");
 
-    const page = (await getMetadata({ url, notes, date, tags })) as Bookmark;
+    const additionalPropertiesList = getInput("additional-properties")
+      ? toArray(getInput("additional-properties"))
+      : undefined;
+
+    const additionalProperties = additionalPropertiesList?.reduce(
+      (acc, property) => {
+        acc[property] = payload[property];
+        return acc;
+      },
+      {}
+    );
+
+    const page = (await getMetadata({
+      url,
+      notes,
+      date,
+      tags,
+      additionalProperties,
+    })) as Bookmark;
     const bookmarks = await addBookmark(filename, page);
     if (!bookmarks) {
       setFailed(`Unable to add bookmark`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import * as github from "@actions/github";
 import { isUrl, isDate } from "./utils.js";
 import { saveBookmarks } from "./save-bookmarks";
 import { addBookmark, Bookmark } from "./add-bookmark";
-import { getMetadata, toArray } from "./get-metadata";
+import { getMetadata } from "./get-metadata";
+import { setAdditionalProperties } from "./set-additional-properties";
 
 type Payload = {
   url: string;
@@ -36,18 +37,7 @@ export async function action() {
     exportVariable("DateBookmarked", date);
 
     const filename = getInput("filename");
-
-    const additionalPropertiesList = getInput("additional-properties")
-      ? toArray(getInput("additional-properties"))
-      : undefined;
-
-    const additionalProperties = additionalPropertiesList?.reduce(
-      (acc, property) => {
-        acc[property] = payload[property];
-        return acc;
-      },
-      {}
-    );
+    const additionalProperties = setAdditionalProperties(payload);
 
     const page = (await getMetadata({
       url,

--- a/src/set-additional-properties.ts
+++ b/src/set-additional-properties.ts
@@ -1,8 +1,38 @@
-import { getInput } from "@actions/core";
+import { getInput, warning } from "@actions/core";
 import { toArray } from "./get-metadata";
+import { Bookmark } from "./add-bookmark";
 
-export function setAdditionalProperties(payload) {
-  const additionalPropertiesList = toArray(getInput("additional-properties"));
+type BookmarkKeys = keyof Bookmark;
+
+const reservedKeys: BookmarkKeys[] = [
+  "title",
+  "site",
+  "date",
+  "description",
+  "url",
+  "author",
+  "type",
+  "image",
+  "notes",
+  "tags",
+];
+
+export function setAdditionalProperties(payload: {
+  [key: string]: string;
+}): { [key: string]: string } | undefined {
+  let additionalPropertiesList = toArray(getInput("additional-properties"));
+
+  if (!additionalPropertiesList.length) return undefined;
+
+  additionalPropertiesList = additionalPropertiesList.filter((property) => {
+    if (reservedKeys.includes(property as BookmarkKeys)) {
+      warning(
+        `The additional property "${property}" is reserved and cannot be used`
+      );
+      return false;
+    }
+    return true;
+  });
 
   if (!additionalPropertiesList.length) return undefined;
 

--- a/src/set-additional-properties.ts
+++ b/src/set-additional-properties.ts
@@ -1,0 +1,13 @@
+import { getInput } from "@actions/core";
+import { toArray } from "./get-metadata";
+
+export function setAdditionalProperties(payload) {
+  const additionalPropertiesList = toArray(getInput("additional-properties"));
+
+  if (!additionalPropertiesList.length) return undefined;
+
+  return additionalPropertiesList.reduce((acc, property: string) => {
+    acc[property] = payload[property];
+    return acc;
+  }, {});
+}

--- a/src/set-additional-properties.ts
+++ b/src/set-additional-properties.ts
@@ -3,6 +3,9 @@ import { toArray } from "./get-metadata";
 import { Bookmark } from "./add-bookmark";
 
 type BookmarkKeys = keyof Bookmark;
+type Payload = { [key: string]: string };
+
+const MAX_ADDITIONAL_PROPERTIES = 5;
 
 const reservedKeys: BookmarkKeys[] = [
   "title",
@@ -17,9 +20,7 @@ const reservedKeys: BookmarkKeys[] = [
   "tags",
 ];
 
-export function setAdditionalProperties(payload: {
-  [key: string]: string;
-}): { [key: string]: string } | undefined {
+export function setAdditionalProperties(payload: Payload): Payload | undefined {
   let additionalPropertiesList = toArray(getInput("additional-properties"));
 
   if (!additionalPropertiesList.length) return undefined;
@@ -36,7 +37,15 @@ export function setAdditionalProperties(payload: {
 
   if (!additionalPropertiesList.length) return undefined;
 
-  return additionalPropertiesList.reduce((acc, property: string) => {
+  if (additionalPropertiesList.length > MAX_ADDITIONAL_PROPERTIES) {
+    throw new Error(
+      `You can only set ${MAX_ADDITIONAL_PROPERTIES} additional properties. You tried to set ${
+        additionalPropertiesList.length
+      }: ${additionalPropertiesList.join(", ")}`
+    );
+  }
+
+  return additionalPropertiesList.reduce((acc: Payload, property: string) => {
     acc[property] = payload[property];
     return acc;
   }, {});


### PR DESCRIPTION
This pull request will enable you to define additional properties to pass along with each bookmark!

1. To the task `inputs` add `additional-properties`. The value is a comma delimited string with property key names.
2. Update your workflow's dispatch inputs to define the new properties using the same key name.

Fixes #154 